### PR TITLE
Check Windows SDK version for D3D12 in CMake

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -188,7 +188,7 @@ Visual Studio configuration will include support for capturing and replaying Dir
 At this point, you can build the solution from the command line or open the
 generated solution with Visual Studio.
 
-**Note: the build uses Windows 10 SDK 10.0.20348.0. Windows 11 SDK 10.0.22000.194 is not compatible at the present time. If you need to specify a Windows 10 SDK, please use `-DCMAKE_SYSTEM_VERSION=10.0.20348.0`. If Python code generation is required, the shell used to run it should have the environment variable `WindowsSDKVersion=10.0.20348.0\` set too.**
+**Note: The D3D12 build uses Windows 10 SDK 10.0.20348.0. Other Windows SDK versions may not be compatible. If you need to specify a Windows SDK, please use `-DCMAKE_SYSTEM_VERSION=10.0.20348.0`. If Python code generation is required, the shell used to run it should set the environment variable `WindowsSDKVersion=10.0.20348.0`.**
 
 When generating a native build on an ARM64 Windows host the Visual Studio
 Installer can be used to install the required Windows SDK version, `10.0.20348.0`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,10 +121,10 @@ endif()
 if(MSVC)
 
     # The host toolchain architecture (i.e. are the compiler and other tools compiled to ARM/Intel 32bit/64bit binaries):
-    message("CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE: " ${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE})
+    message(STATUS "CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE: " ${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE})
     # The platform name (architecture), we want to build our project for:
     # e.g. passed through the commandline -A option: cmake -G "Visual Studio 17 2022" -A ARM64
-    message("CMAKE_GENERATOR_PLATFORM: " ${CMAKE_GENERATOR_PLATFORM})
+    message(STATUS "CMAKE_GENERATOR_PLATFORM: " ${CMAKE_GENERATOR_PLATFORM})
 
     set(GFXR_ARM_WINDOWS_BUILD FALSE)
     if(CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
@@ -173,7 +173,22 @@ if(MSVC)
     endif()
 
     # Add option to enable/disable AGS support.
-    option(GFXRECON_AGS_SUPPORT "Build with AGS support enabled" ON)
+    option(GFXRECON_AGS_SUPPORT "Build with AGS support enabled. Ignored if D3D12_SUPPORT=OFF." ON)
+    
+    if (${D3D12_SUPPORT})
+        if (${GFXRECON_AGS_SUPPORT})
+            if (CMAKE_SIZEOF_VOID_P EQUAL 8)
+                find_package(AGS)
+                if (TARGET AGS::AGS)
+                    add_definitions(-DGFXRECON_AGS_SUPPORT)
+                
+                    # The value for option GFXRECON_AGS_SUPPORT gets cached so use a non-cached variable
+                    # to determine the final result.
+                    set(GFXRECON_AGS_SUPPORT_FINAL ON)
+                endif() # TARGET AGS::AGS
+            endif() # CMAKE_SIZEOF_VOID_P EQUAL 8
+        endif() # GFXRECON_AGS_SUPPORT
+    endif() # D3D12_SUPPORT
 	
 else(MSVC)
     # Turn off D3D12 support for non MSVC builds.
@@ -191,25 +206,12 @@ else(MSVC)
 endif(MSVC)
 
 # GFXReconstruct provided find modules
-if(${D3D12_SUPPORT})
-    if (${GFXRECON_AGS_SUPPORT})
-        find_package(AGS)
-    endif() # GFXRECON_AGS_SUPPORT
-endif() # D3D12_SUPPORT
-
 if(WIN32)
 find_package(Detours)
 endif() # WIN32
 
 find_package(LZ4)
 find_package(ZSTD)
-
-
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    if (TARGET AGS::AGS)
-        add_definitions(-DGFXRECON_AGS_SUPPORT)
-    endif()
-endif()
 
 if(UNIX)
     option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ if(MSVC)
     # e.g. passed through the commandline -A option: cmake -G "Visual Studio 17 2022" -A ARM64
     message(STATUS "CMAKE_GENERATOR_PLATFORM: " ${CMAKE_GENERATOR_PLATFORM})
 
+    message(STATUS "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION: " ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION})
+
     set(GFXR_ARM_WINDOWS_BUILD FALSE)
     if(CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64")
         set(GFXR_ARM_WINDOWS_BUILD TRUE)
@@ -163,6 +165,16 @@ if(MSVC)
         if(${CONVERT_EXPERIMENTAL_D3D12})
             add_definitions(-DCONVERT_EXPERIMENTAL_D3D12)
         endif()
+
+        # Check Windows SDK version and print warning if there is a mismatch.
+        if (NOT ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} STREQUAL "10.0.20348.0")
+            message(WARNING
+                "D3D12 support is authored against Windows SDK 10.0.20348.0. SDK verison "
+                "${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} may not be compatible. If you encounter build errors, "
+                "set D3D12_SUPPORT=OFF or configure the build with the recommended Windows SDK version. See BUILD.md "
+                "for more information.")
+        endif()
+        
     else()
         set(BUILD_LAUNCHER_AND_INTERCEPTOR OFF)
     endif()

--- a/framework/decode/CMakeLists.txt
+++ b/framework/decode/CMakeLists.txt
@@ -206,7 +206,7 @@ target_sources(gfxrecon_decode
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_SOURCE_DIR}/framework/generated/generated_dx12_call_id_to_string.h>
 )
 
-if(${GFXRECON_AGS_SUPPORT})
+if (${GFXRECON_AGS_SUPPORT_FINAL})
 target_sources(gfxrecon_decode
                PRIVATE
                     ${CMAKE_CURRENT_LIST_DIR}/custom_ags_decoder.h

--- a/framework/encode/CMakeLists.txt
+++ b/framework/encode/CMakeLists.txt
@@ -69,13 +69,13 @@ target_sources(gfxrecon_encode
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_state_writer.h>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_state_writer.cpp>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dxgi_dispatch_table.h>
-                    $<$<BOOL:${GFXRECON_AGS_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/ags_dispatch_table.h>
-                    $<$<BOOL:${GFXRECON_AGS_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/custom_ags_wrappers.h>
-                    $<$<BOOL:${GFXRECON_AGS_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/custom_ags_wrappers.cpp>
-                    $<$<BOOL:${GFXRECON_AGS_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/custom_ags_api_call_encoders.h>
-                    $<$<BOOL:${GFXRECON_AGS_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/custom_ags_api_call_encoders.cpp>
-                    $<$<BOOL:${GFXRECON_AGS_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/custom_ags_state_table.h>
-                    $<$<BOOL:${GFXRECON_AGS_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/custom_ags_state_table.cpp>
+                    $<$<BOOL:${GFXRECON_AGS_SUPPORT_FINAL}>:${CMAKE_CURRENT_LIST_DIR}/ags_dispatch_table.h>
+                    $<$<BOOL:${GFXRECON_AGS_SUPPORT_FINAL}>:${CMAKE_CURRENT_LIST_DIR}/custom_ags_wrappers.h>
+                    $<$<BOOL:${GFXRECON_AGS_SUPPORT_FINAL}>:${CMAKE_CURRENT_LIST_DIR}/custom_ags_wrappers.cpp>
+                    $<$<BOOL:${GFXRECON_AGS_SUPPORT_FINAL}>:${CMAKE_CURRENT_LIST_DIR}/custom_ags_api_call_encoders.h>
+                    $<$<BOOL:${GFXRECON_AGS_SUPPORT_FINAL}>:${CMAKE_CURRENT_LIST_DIR}/custom_ags_api_call_encoders.cpp>
+                    $<$<BOOL:${GFXRECON_AGS_SUPPORT_FINAL}>:${CMAKE_CURRENT_LIST_DIR}/custom_ags_state_table.h>
+                    $<$<BOOL:${GFXRECON_AGS_SUPPORT_FINAL}>:${CMAKE_CURRENT_LIST_DIR}/custom_ags_state_table.cpp>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/iunknown_wrapper.h>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/iunknown_wrapper.cpp>
                     $<$<BOOL:${D3D12_SUPPORT}>:${CMAKE_CURRENT_LIST_DIR}/dx12_rv_annotator.h>

--- a/framework/util/CMakeLists.txt
+++ b/framework/util/CMakeLists.txt
@@ -151,7 +151,7 @@ if (WAYLAND_LIBRARY)
     target_compile_definitions(gfxrecon_util PUBLIC "WAYLAND_LIBRARY=\"${WAYLAND_LIBRARY}\"")
 endif()
 
-if(${GFXRECON_AGS_SUPPORT})
+if (${GFXRECON_AGS_SUPPORT_FINAL})
     target_link_libraries(gfxrecon_util AGS::AGS)
 endif()
 

--- a/layer/CMakeLists.txt
+++ b/layer/CMakeLists.txt
@@ -38,7 +38,7 @@ if (D3D12_SUPPORT)
         add_subdirectory(gfxrecon_interceptor)
     endif()
 
-    if (${GFXRECON_AGS_SUPPORT})
+    if (${GFXRECON_AGS_SUPPORT_FINAL})
       add_subdirectory(ags_capture)
     endif()
 endif()


### PR DESCRIPTION
Issue a CMake warning if the version doesn't match the version D3D12 was created with.