### PR TITLE
Enable trimming to GPU queue submission range

### DIFF
--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -92,8 +92,9 @@ CaptureManager::CaptureManager(format::ApiFamilyId api_family) :
     api_family_(api_family), force_file_flush_(false), timestamp_filename_(true),
     memory_tracking_mode_(CaptureSettings::MemoryTrackingMode::kPageGuard), page_guard_align_buffer_sizes_(false),
     page_guard_track_ahb_memory_(false), page_guard_unblock_sigsegv_(false), page_guard_signal_handler_watcher_(false),
-    page_guard_memory_mode_(kMemoryModeShadowInternal), trim_enabled_(false), trim_current_range_(0),
-    current_frame_(kFirstFrame), capture_mode_(kModeWrite), previous_hotkey_state_(false),
+    page_guard_memory_mode_(kMemoryModeShadowInternal), trim_enabled_(false),
+    trim_boundary_(CaptureSettings::TrimBoundary::kUnknown), trim_current_range_(0), current_frame_(kFirstFrame),
+    queue_submit_count_(0), capture_mode_(kModeWrite), previous_hotkey_state_(false),
     previous_runtime_trigger_state_(CaptureSettings::RuntimeTriggerState::kNotUsed), debug_layer_(false),
     debug_device_lost_(false), screenshot_prefix_(""), screenshots_enabled_(false), disable_dxr_(false),
     accel_struct_padding_(0), iunknown_wrapping_(false), force_command_serialization_(false), queue_zero_only_(false),
@@ -321,15 +322,22 @@ bool CaptureManager::Initialize(std::string base_filename, const CaptureSettings
     }
     else
     {
-        // Override default kModeWrite capture mode.
-        trim_enabled_ = true;
+        GFXRECON_ASSERT(trace_settings.trim_boundary != CaptureSettings::TrimBoundary::kUnknown);
 
-        // Determine if trim starts at the first frame
+        // Override default kModeWrite capture mode.
+        trim_enabled_  = true;
+        trim_boundary_ = trace_settings.trim_boundary;
+
+        // Check if trim ranges were specified.
         if (!trace_settings.trim_ranges.empty())
         {
+            GFXRECON_ASSERT((trim_boundary_ == CaptureSettings::TrimBoundary::kFrames) ||
+                            (trim_boundary_ == CaptureSettings::TrimBoundary::kQueueSubmits));
+
             trim_ranges_ = trace_settings.trim_ranges;
 
-            if (trim_ranges_[0].first == current_frame_)
+            // Determine if trim starts at the first frame
+            if ((trim_boundary_ == CaptureSettings::TrimBoundary::kFrames) && (trim_ranges_[0].first == current_frame_))
             {
                 // When capturing from the first frame, state tracking only needs to be enabled if there is more than
                 // one capture range.
@@ -345,10 +353,13 @@ bool CaptureManager::Initialize(std::string base_filename, const CaptureSettings
                 capture_mode_ = kModeTrack;
             }
         }
-        // Check if trim is enabled by hot-key trigger at the first frame
+        // Check if trim is enabled by hot-key trigger at the first frame.
         else if (!trace_settings.trim_key.empty() ||
                  trace_settings.runtime_capture_trigger != CaptureSettings::RuntimeTriggerState::kNotUsed)
         {
+            // Capture key/trigger only support frames as trim boundaries.
+            GFXRECON_ASSERT(trim_boundary_ == CaptureSettings::TrimBoundary::kFrames);
+
             trim_key_                       = trace_settings.trim_key;
             trim_key_frames_                = trace_settings.trim_key_frames;
             previous_runtime_trigger_state_ = trace_settings.runtime_capture_trigger;
@@ -369,7 +380,10 @@ bool CaptureManager::Initialize(std::string base_filename, const CaptureSettings
         }
         else
         {
-            capture_mode_ = kModeTrack;
+            // if/else blocks above should have covered all "else" cases from the parent conditional.
+            GFXRECON_ASSERT(false);
+            trim_boundary_ = CaptureSettings::TrimBoundary::kUnknown;
+            capture_mode_  = kModeTrack;
         }
     }
 
@@ -592,11 +606,11 @@ bool CaptureManager::RuntimeTriggerDisabled()
     return result;
 }
 
-void CaptureManager::CheckContinueCaptureForWriteMode()
+void CaptureManager::CheckContinueCaptureForWriteMode(uint32_t current_boundary_count)
 {
     if (!trim_ranges_.empty())
     {
-        if (current_frame_ == (trim_ranges_[trim_current_range_].last + 1))
+        if (current_boundary_count == (trim_ranges_[trim_current_range_].last + 1))
         {
             // Stop recording and close file.
             DeactivateTrimming();
@@ -606,16 +620,17 @@ void CaptureManager::CheckContinueCaptureForWriteMode()
             ++trim_current_range_;
             if (trim_current_range_ >= trim_ranges_.size())
             {
-                // No more frames to capture. Capture can be disabled and resources can be released.
-                trim_enabled_ = false;
-                capture_mode_ = kModeDisabled;
+                // No more trim ranges to capture. Capture can be disabled and resources can be released.
+                trim_enabled_  = false;
+                trim_boundary_ = CaptureSettings::TrimBoundary::kUnknown;
+                capture_mode_  = kModeDisabled;
                 DestroyStateTracker();
                 compressor_ = nullptr;
             }
-            else if (trim_ranges_[trim_current_range_].first == current_frame_)
+            else if (trim_ranges_[trim_current_range_].first == current_boundary_count)
             {
-                // Trimming was configured to capture two consecutive frames, so we need to start a new capture
-                // file for the current frame.
+                // Trimming was configured to capture two consecutive ranges, so we need to start a new capture
+                // file for the current range.
                 const auto& trim_range = trim_ranges_[trim_current_range_];
                 bool        success    = CreateCaptureFile(CreateTrimFilename(base_filename_, trim_range));
                 if (success)
@@ -632,7 +647,7 @@ void CaptureManager::CheckContinueCaptureForWriteMode()
         }
     }
     else if (IsTrimHotkeyPressed() ||
-             ((trim_key_frames_ > 0) && (current_frame_ >= (trim_key_first_frame_ + trim_key_frames_))) ||
+             ((trim_key_frames_ > 0) && (current_boundary_count >= (trim_key_first_frame_ + trim_key_frames_))) ||
              RuntimeTriggerDisabled())
     {
         // Stop recording and close file.
@@ -641,11 +656,11 @@ void CaptureManager::CheckContinueCaptureForWriteMode()
     }
 }
 
-void CaptureManager::CheckStartCaptureForTrackMode()
+void CaptureManager::CheckStartCaptureForTrackMode(uint32_t current_boundary_count)
 {
     if (!trim_ranges_.empty())
     {
-        if (current_frame_ == trim_ranges_[trim_current_range_].first)
+        if (current_boundary_count == trim_ranges_[trim_current_range_].first)
         {
             const auto& trim_range = trim_ranges_[trim_current_range_];
             bool        success    = CreateCaptureFile(CreateTrimFilename(base_filename_, trim_range));
@@ -667,7 +682,7 @@ void CaptureManager::CheckStartCaptureForTrackMode()
         if (success)
         {
 
-            trim_key_first_frame_ = current_frame_;
+            trim_key_first_frame_ = current_boundary_count;
             ActivateTrimming();
         }
         else
@@ -728,19 +743,19 @@ void CaptureManager::EndFrame()
 
     ++current_frame_;
 
-    if (trim_enabled_)
+    if (trim_enabled_ && (trim_boundary_ == CaptureSettings::TrimBoundary::kFrames))
     {
         if ((capture_mode_ & kModeWrite) == kModeWrite)
         {
             // Currently capturing a frame range.
             // Check for end of range or hotkey trigger to stop capture.
-            CheckContinueCaptureForWriteMode();
+            CheckContinueCaptureForWriteMode(current_frame_);
         }
         else if ((capture_mode_ & kModeTrack) == kModeTrack)
         {
             // Capture is not active.
             // Check for start of capture frame range or hotkey trigger to start capture
-            CheckStartCaptureForTrackMode();
+            CheckStartCaptureForTrackMode(current_frame_);
         }
     }
 
@@ -751,6 +766,32 @@ void CaptureManager::EndFrame()
     }
 }
 
+void CaptureManager::PreQueueSubmit()
+{
+    ++queue_submit_count_;
+
+    if (trim_enabled_ && (trim_boundary_ == CaptureSettings::TrimBoundary::kQueueSubmits))
+    {
+        if (((capture_mode_ & kModeWrite) != kModeWrite) && ((capture_mode_ & kModeTrack) == kModeTrack))
+        {
+            // Capture is not active, check for start of capture frame range.
+            CheckStartCaptureForTrackMode(queue_submit_count_);
+        }
+    }
+}
+
+void CaptureManager::PostQueueSubmit()
+{
+    if (trim_enabled_ && (trim_boundary_ == CaptureSettings::TrimBoundary::kQueueSubmits))
+    {
+        if ((capture_mode_ & kModeWrite) == kModeWrite)
+        {
+            // Currently capturing a queue submit range, check for end of range.
+            CheckContinueCaptureForWriteMode(queue_submit_count_);
+        }
+    }
+}
+
 std::string CaptureManager::CreateTrimFilename(const std::string& base_filename, const util::UintRange& trim_range)
 {
     GFXRECON_ASSERT(trim_range.last >= trim_range.first);
@@ -758,7 +799,19 @@ std::string CaptureManager::CreateTrimFilename(const std::string& base_filename,
     std::string range_string = "_";
 
     uint32_t    total        = trim_range.last - trim_range.first + 1;
-    const char* boundary_str = total > 1 ? "frames_" : "frame_";
+    const char* boundary_str = "";
+    switch (trim_boundary_)
+    {
+        case CaptureSettings::TrimBoundary::kFrames:
+            boundary_str = total > 1 ? "frames_" : "frame_";
+            break;
+        case CaptureSettings::TrimBoundary::kQueueSubmits:
+            boundary_str = total > 1 ? "queue_submits_" : "queue_submit_";
+            break;
+        default:
+            GFXRECON_ASSERT(FALSE);
+            break;
+    }
 
     range_string += boundary_str;
     range_string += std::to_string(trim_range.first);

--- a/framework/encode/capture_manager.cpp
+++ b/framework/encode/capture_manager.cpp
@@ -323,17 +323,12 @@ bool CaptureManager::Initialize(std::string base_filename, const CaptureSettings
     {
         // Override default kModeWrite capture mode.
         trim_enabled_ = true;
-        std::transform(trace_settings.trim_ranges.begin(),
-                       trace_settings.trim_ranges.end(),
-                       std::back_inserter(trim_ranges_),
-                       [](const util::UintRange& range) {
-                           GFXRECON_ASSERT(range.last >= range.first);
-                           return TrimRange({ range.first, (range.last - range.first + 1) });
-                       });
 
         // Determine if trim starts at the first frame
         if (!trace_settings.trim_ranges.empty())
         {
+            trim_ranges_ = trace_settings.trim_ranges;
+
             if (trim_ranges_[0].first == current_frame_)
             {
                 // When capturing from the first frame, state tracking only needs to be enabled if there is more than
@@ -601,8 +596,7 @@ void CaptureManager::CheckContinueCaptureForWriteMode()
 {
     if (!trim_ranges_.empty())
     {
-        --trim_ranges_[trim_current_range_].total;
-        if (trim_ranges_[trim_current_range_].total == 0)
+        if (current_frame_ == (trim_ranges_[trim_current_range_].last + 1))
         {
             // Stop recording and close file.
             DeactivateTrimming();
@@ -622,8 +616,8 @@ void CaptureManager::CheckContinueCaptureForWriteMode()
             {
                 // Trimming was configured to capture two consecutive frames, so we need to start a new capture
                 // file for the current frame.
-                const TrimRange& trim_range = trim_ranges_[trim_current_range_];
-                bool             success    = CreateCaptureFile(CreateTrimFilename(base_filename_, trim_range));
+                const auto& trim_range = trim_ranges_[trim_current_range_];
+                bool        success    = CreateCaptureFile(CreateTrimFilename(base_filename_, trim_range));
                 if (success)
                 {
                     ActivateTrimming();
@@ -651,10 +645,10 @@ void CaptureManager::CheckStartCaptureForTrackMode()
 {
     if (!trim_ranges_.empty())
     {
-        if (trim_ranges_[trim_current_range_].first == current_frame_)
+        if (current_frame_ == trim_ranges_[trim_current_range_].first)
         {
-            const TrimRange& trim_range = trim_ranges_[trim_current_range_];
-            bool             success    = CreateCaptureFile(CreateTrimFilename(base_filename_, trim_range));
+            const auto& trim_range = trim_ranges_[trim_current_range_];
+            bool        success    = CreateCaptureFile(CreateTrimFilename(base_filename_, trim_range));
             if (success)
             {
                 ActivateTrimming();
@@ -757,23 +751,21 @@ void CaptureManager::EndFrame()
     }
 }
 
-std::string CaptureManager::CreateTrimFilename(const std::string& base_filename, const TrimRange& trim_range)
+std::string CaptureManager::CreateTrimFilename(const std::string& base_filename, const util::UintRange& trim_range)
 {
-    assert(trim_range.total > 0);
+    GFXRECON_ASSERT(trim_range.last >= trim_range.first);
 
     std::string range_string = "_";
 
-    if (trim_range.total == 1)
+    uint32_t    total        = trim_range.last - trim_range.first + 1;
+    const char* boundary_str = total > 1 ? "frames_" : "frame_";
+
+    range_string += boundary_str;
+    range_string += std::to_string(trim_range.first);
+    if (total > 1)
     {
-        range_string += "frame_";
-        range_string += std::to_string(trim_range.first);
-    }
-    else
-    {
-        range_string += "frames_";
-        range_string += std::to_string(trim_range.first);
         range_string += "_through_";
-        range_string += std::to_string((trim_range.first + trim_range.total) - 1);
+        range_string += std::to_string(trim_range.last);
     }
 
     return util::filepath::InsertFilenamePostfix(base_filename, range_string);

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -116,13 +116,18 @@ class CaptureManager
 
     void EndFrame();
 
+    // Pre/PostQueueSubmit to be called immediately before and after work is submitted to the GPU by vkQueueSubmit for
+    // Vulkan or by ID3D12CommandQueue::ExecuteCommandLists for DX12.
+    void PreQueueSubmit();
+    void PostQueueSubmit();
+
     bool ShouldTriggerScreenshot();
 
     util::ScreenshotFormat GetScreenshotFormat() { return screenshot_format_; }
 
-    void CheckContinueCaptureForWriteMode();
+    void CheckContinueCaptureForWriteMode(uint32_t current_boundary_count);
 
-    void CheckStartCaptureForTrackMode();
+    void CheckStartCaptureForTrackMode(uint32_t current_boundary_count);
 
     bool IsTrimHotkeyPressed();
 
@@ -318,12 +323,14 @@ class CaptureManager
     bool                                    page_guard_signal_handler_watcher_;
     PageGuardMemoryMode                     page_guard_memory_mode_;
     bool                                    trim_enabled_;
+    CaptureSettings::TrimBoundary           trim_boundary_;
     std::vector<util::UintRange>            trim_ranges_;
     std::string                             trim_key_;
     uint32_t                                trim_key_frames_;
     uint32_t                                trim_key_first_frame_;
     size_t                                  trim_current_range_;
     uint32_t                                current_frame_;
+    uint32_t                                queue_submit_count_;
     CaptureMode                             capture_mode_;
     bool                                    previous_hotkey_state_;
     CaptureSettings::RuntimeTriggerState    previous_runtime_trigger_state_;

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -211,6 +211,12 @@ class CaptureManager
         std::vector<uint8_t> scratch_buffer_;
     };
 
+    struct TrimRange
+    {
+        uint32_t first{ 0 }; // First frame to capture.
+        uint32_t total{ 0 }; // Total number of frames to capture.
+    };
+
   protected:
     static bool CreateInstance(std::function<CaptureManager*()> GetInstanceFunc, std::function<void()> NewInstanceFunc);
 
@@ -250,7 +256,7 @@ class CaptureManager
     bool                                GetDisableDxrSetting() const { return disable_dxr_; }
     auto                                GetAccelStructPaddingSetting() const { return accel_struct_padding_; }
 
-    std::string CreateTrimFilename(const std::string& base_filename, const CaptureSettings::TrimRange& trim_range);
+    std::string CreateTrimFilename(const std::string& base_filename, const TrimRange& trim_range);
     bool        CreateCaptureFile(const std::string& base_filename);
     void        ActivateTrimming();
     void        DeactivateTrimming();
@@ -318,7 +324,7 @@ class CaptureManager
     bool                                    page_guard_signal_handler_watcher_;
     PageGuardMemoryMode                     page_guard_memory_mode_;
     bool                                    trim_enabled_;
-    std::vector<CaptureSettings::TrimRange> trim_ranges_;
+    std::vector<TrimRange>                  trim_ranges_;
     std::string                             trim_key_;
     uint32_t                                trim_key_frames_;
     uint32_t                                trim_key_first_frame_;

--- a/framework/encode/capture_manager.h
+++ b/framework/encode/capture_manager.h
@@ -211,12 +211,6 @@ class CaptureManager
         std::vector<uint8_t> scratch_buffer_;
     };
 
-    struct TrimRange
-    {
-        uint32_t first{ 0 }; // First frame to capture.
-        uint32_t total{ 0 }; // Total number of frames to capture.
-    };
-
   protected:
     static bool CreateInstance(std::function<CaptureManager*()> GetInstanceFunc, std::function<void()> NewInstanceFunc);
 
@@ -256,7 +250,7 @@ class CaptureManager
     bool                                GetDisableDxrSetting() const { return disable_dxr_; }
     auto                                GetAccelStructPaddingSetting() const { return accel_struct_padding_; }
 
-    std::string CreateTrimFilename(const std::string& base_filename, const TrimRange& trim_range);
+    std::string CreateTrimFilename(const std::string& base_filename, const util::UintRange& trim_range);
     bool        CreateCaptureFile(const std::string& base_filename);
     void        ActivateTrimming();
     void        DeactivateTrimming();
@@ -324,7 +318,7 @@ class CaptureManager
     bool                                    page_guard_signal_handler_watcher_;
     PageGuardMemoryMode                     page_guard_memory_mode_;
     bool                                    trim_enabled_;
-    std::vector<TrimRange>                  trim_ranges_;
+    std::vector<util::UintRange>            trim_ranges_;
     std::string                             trim_key_;
     uint32_t                                trim_key_frames_;
     uint32_t                                trim_key_first_frame_;

--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -476,7 +476,8 @@ void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* setti
     // trim ranges and trim hotkey are exclusive
     // with trim key will be parsed only
     // if trim ranges is empty, else it will be ignored
-    ParseTrimRangeString(FindOption(options, kOptionKeyCaptureFrames), &settings->trace_settings_.trim_ranges);
+    ParseUintRangeList(
+        FindOption(options, kOptionKeyCaptureFrames), &settings->trace_settings_.trim_ranges, "capture frames");
     std::string trim_key_option        = FindOption(options, kOptionKeyCaptureTrigger);
     std::string trim_key_frames_option = FindOption(options, kOptionKeyCaptureTriggerFrames);
     if (!trim_key_option.empty())
@@ -530,7 +531,9 @@ void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* setti
     // Screenshot options
     settings->trace_settings_.screenshot_dir =
         FindOption(options, kOptionKeyScreenshotDir, settings->trace_settings_.screenshot_dir);
-    ParseFramesList(FindOption(options, kOptionKeyScreenshotFrames), &settings->trace_settings_.screenshot_ranges);
+    ParseUintRangeList(FindOption(options, kOptionKeyScreenshotFrames),
+                       &settings->trace_settings_.screenshot_ranges,
+                       "screenshot frames");
     settings->trace_settings_.screenshot_format = ParseScreenshotFormatString(
         FindOption(options, kOptionKeyScreenshotFormat), settings->trace_settings_.screenshot_format);
 
@@ -778,143 +781,19 @@ util::Log::Severity CaptureSettings::ParseLogLevelString(const std::string&  val
     return result;
 }
 
-void CaptureSettings::ParseTrimRangeString(const std::string&                       value_string,
-                                           std::vector<CaptureSettings::TrimRange>* ranges)
-{
-    assert(ranges != nullptr);
-
-    if (!value_string.empty())
-    {
-        std::istringstream value_string_input;
-        value_string_input.str(value_string);
-
-        for (std::string range; std::getline(value_string_input, range, ',');)
-        {
-            if (range.empty() || (std::count(range.begin(), range.end(), '-') > 1))
-            {
-                GFXRECON_LOG_WARNING("Settings Loader: Ignoring invalid capture frame range \"%s\"", range.c_str());
-                continue;
-            }
-
-            util::strings::RemoveWhitespace(range);
-
-            // Split string on '-' delimiter.
-            bool                     invalid = false;
-            std::vector<std::string> values;
-            std::istringstream       range_input;
-            range_input.str(range);
-
-            for (std::string value; std::getline(range_input, value, '-');)
-            {
-                if (value.empty())
-                {
-                    break;
-                }
-
-                // Check that the value string only contains numbers.
-                size_t count = std::count_if(value.begin(), value.end(), ::isdigit);
-                if (count == value.length())
-                {
-                    values.push_back(value);
-                }
-                else
-                {
-                    GFXRECON_LOG_WARNING("Settings Loader: Ignoring invalid capture frame range \"%s\", which contains "
-                                         "non-numeric values",
-                                         range.c_str());
-                    invalid = true;
-                    break;
-                }
-            }
-
-            if (!invalid)
-            {
-                CaptureSettings::TrimRange trim_range;
-
-                if (values.size() == 1)
-                {
-                    if (std::count(range.begin(), range.end(), '-') == 0)
-                    {
-                        trim_range.first = std::stoi(values[0]);
-                        trim_range.total = 1;
-                    }
-                    else
-                    {
-                        GFXRECON_LOG_WARNING("Settings Loader: Ignoring invalid capture frame range \"%s\"",
-                                             range.c_str());
-                        continue;
-                    }
-                }
-                else if (values.size() == 2)
-                {
-                    trim_range.first = std::stoi(values[0]);
-
-                    uint32_t last = std::stoi(values[1]);
-                    if (last >= trim_range.first)
-                    {
-                        trim_range.total = (last - trim_range.first) + 1;
-                    }
-                    else
-                    {
-                        GFXRECON_LOG_WARNING(
-                            "Settings Loader: Ignoring invalid capture frame range \"%s\", where first "
-                            "frame is greater than last frame",
-                            range.c_str());
-                        continue;
-                    }
-                }
-                else
-                {
-                    GFXRECON_LOG_WARNING("Settings Loader: Ignoring invalid capture frame range \"%s\"", range.c_str());
-                    continue;
-                }
-
-                // Check for invalid start frame of 0.
-                if (trim_range.first == 0)
-                {
-                    GFXRECON_LOG_WARNING(
-                        "Settings Loader: Ignoring invalid capture frame range \"%s\", with first frame equal to zero",
-                        range.c_str());
-                    continue;
-                }
-
-                uint32_t next_allowed = 0;
-
-                // Check that start frame is outside the bounds of the previous range.
-                if (!ranges->empty())
-                {
-                    // This produces the number of the frame after the last frame in the range.
-                    next_allowed = ranges->back().first + ranges->back().total;
-                }
-
-                if (trim_range.first >= next_allowed)
-                {
-                    ranges->emplace_back(trim_range);
-                }
-                else
-                {
-                    GFXRECON_LOG_WARNING("Settings Loader: Ignoring invalid capture frame range \"%s\", "
-                                         "where start frame precedes the end of the previous range \"%u-%u\"",
-                                         range.c_str(),
-                                         ranges->back().first,
-                                         (next_allowed - 1));
-                }
-            }
-        }
-    }
-}
-
-void CaptureSettings::ParseFramesList(const std::string& value_string, std::vector<util::FrameRange>* frames)
+void CaptureSettings::ParseUintRangeList(const std::string&            value_string,
+                                         std::vector<util::UintRange>* frames,
+                                         const char*                   option_name)
 {
     GFXRECON_ASSERT(frames != nullptr);
 
     if (!value_string.empty())
     {
-        std::vector<gfxrecon::util::FrameRange> frame_ranges = gfxrecon::util::GetFrameRanges(value_string);
+        std::vector<gfxrecon::util::UintRange> frame_ranges = util::GetUintRanges(value_string.c_str(), option_name);
 
         for (uint32_t i = 0; i < frame_ranges.size(); ++i)
         {
-            util::FrameRange range{};
+            util::UintRange range{};
             range.first = frame_ranges[i].first;
             range.last  = frame_ranges[i].last;
             frames->push_back(range);

--- a/framework/encode/capture_settings.cpp
+++ b/framework/encode/capture_settings.cpp
@@ -90,6 +90,8 @@ GFXRECON_BEGIN_NAMESPACE(encode)
 #define CAPTURE_ANDROID_TRIGGER_UPPER                        "CAPTURE_ANDROID_TRIGGER"
 #define CAPTURE_IUNKNOWN_WRAPPING_LOWER                      "capture_iunknown_wrapping"
 #define CAPTURE_IUNKNOWN_WRAPPING_UPPER                      "CAPTURE_IUNKNOWN_WRAPPING"
+#define CAPTURE_QUEUE_SUBMITS_LOWER                          "capture_queue_submits"
+#define CAPTURE_QUEUE_SUBMITS_UPPER                          "CAPTURE_QUEUE_SUBMITS"
 #define PAGE_GUARD_COPY_ON_MAP_LOWER                         "page_guard_copy_on_map"
 #define PAGE_GUARD_COPY_ON_MAP_UPPER                         "PAGE_GUARD_COPY_ON_MAP"
 #define PAGE_GUARD_SEPARATE_READ_LOWER                       "page_guard_separate_read"
@@ -160,6 +162,7 @@ const char kCaptureFramesEnvVar[]                            = GFXRECON_ENV_VAR_
 const char kCaptureTriggerEnvVar[]                           = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_LOWER;
 const char kCaptureTriggerFramesEnvVar[]                     = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_FRAMES_LOWER;
 const char kCaptureIUnknownWrappingEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX CAPTURE_IUNKNOWN_WRAPPING_LOWER;
+const char kCaptureQueueSubmitsEnvVar[]                      = GFXRECON_ENV_VAR_PREFIX CAPTURE_QUEUE_SUBMITS_LOWER;
 const char kPageGuardCopyOnMapEnvVar[]                       = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_COPY_ON_MAP_LOWER;
 const char kPageGuardSeparateReadEnvVar[]                    = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_SEPARATE_READ_LOWER;
 const char kPageGuardPersistentMemoryEnvVar[]                = GFXRECON_ENV_VAR_PREFIX PAGE_GUARD_PERSISTENT_MEMORY_LOWER;
@@ -220,6 +223,7 @@ const char kPageGuardSignalHandlerWatcherMaxRestoresEnvVar[] = GFXRECON_ENV_VAR_
 const char kCaptureTriggerEnvVar[]                           = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_UPPER;
 const char kCaptureTriggerFramesEnvVar[]                     = GFXRECON_ENV_VAR_PREFIX CAPTURE_TRIGGER_FRAMES_UPPER;
 const char kCaptureIUnknownWrappingEnvVar[]                  = GFXRECON_ENV_VAR_PREFIX CAPTURE_IUNKNOWN_WRAPPING_UPPER;
+const char kCaptureQueueSubmitsEnvVar[]                      = GFXRECON_ENV_VAR_PREFIX CAPTURE_QUEUE_SUBMITS_UPPER;
 const char kDebugLayerEnvVar[]                               = GFXRECON_ENV_VAR_PREFIX DEBUG_LAYER_UPPER;
 const char kDebugDeviceLostEnvVar[]                          = GFXRECON_ENV_VAR_PREFIX DEBUG_DEVICE_LOST_UPPER;
 const char kDisableDxrEnvVar[]                               = GFXRECON_ENV_VAR_PREFIX DISABLE_DXR_UPPER;
@@ -260,6 +264,7 @@ const std::string kOptionKeyCaptureFrames                            = std::stri
 const std::string kOptionKeyCaptureTrigger                           = std::string(kSettingsFilter) + std::string(CAPTURE_TRIGGER_LOWER);
 const std::string kOptionKeyCaptureTriggerFrames                     = std::string(kSettingsFilter) + std::string(CAPTURE_TRIGGER_FRAMES_LOWER);
 const std::string kOptionKeyCaptureIUnknownWrapping                  = std::string(kSettingsFilter) + std::string(CAPTURE_IUNKNOWN_WRAPPING_LOWER);
+const std::string kOptionKeyCaptureQueueSubmits                      = std::string(kSettingsFilter) + std::string(CAPTURE_QUEUE_SUBMITS_LOWER);
 const std::string kOptionKeyPageGuardCopyOnMap                       = std::string(kSettingsFilter) + std::string(PAGE_GUARD_COPY_ON_MAP_LOWER);
 const std::string kOptionKeyPageGuardSeparateRead                    = std::string(kSettingsFilter) + std::string(PAGE_GUARD_SEPARATE_READ_LOWER);
 const std::string kOptionKeyPageGuardPersistentMemory                = std::string(kSettingsFilter) + std::string(PAGE_GUARD_PERSISTENT_MEMORY_LOWER);
@@ -331,6 +336,10 @@ void CaptureSettings::LoadRunTimeEnvVarSettings(CaptureSettings* settings)
         std::string value = util::platform::GetEnv(kCaptureAndroidTriggerEnvVar);
         settings->trace_settings_.runtime_capture_trigger =
             ParseAndroidRunTimeTrimState(value, settings->trace_settings_.runtime_capture_trigger);
+        if (!settings->trace_settings_.runtime_capture_trigger.empty())
+        {
+            settings->trace_settings_.trim_boundary = TrimBoundary::kFrames;
+        }
     }
 #endif
 }
@@ -391,6 +400,7 @@ void CaptureSettings::LoadOptionsEnvVar(OptionsMap* options)
     LoadSingleOptionEnvVar(options, kCaptureFramesEnvVar, kOptionKeyCaptureFrames);
     LoadSingleOptionEnvVar(options, kCaptureTriggerEnvVar, kOptionKeyCaptureTrigger);
     LoadSingleOptionEnvVar(options, kCaptureTriggerFramesEnvVar, kOptionKeyCaptureTriggerFrames);
+    LoadSingleOptionEnvVar(options, kCaptureQueueSubmitsEnvVar, kOptionKeyCaptureQueueSubmits);
 
     // Page guard environment variables
     LoadSingleOptionEnvVar(options, kPageGuardCopyOnMapEnvVar, kOptionKeyPageGuardCopyOnMap);
@@ -473,11 +483,36 @@ void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* setti
         FindOption(options, kOptionKeyMemoryTrackingMode), settings->trace_settings_.memory_tracking_mode);
 
     // Trimming options:
-    // trim ranges and trim hotkey are exclusive
-    // with trim key will be parsed only
-    // if trim ranges is empty, else it will be ignored
-    ParseUintRangeList(
-        FindOption(options, kOptionKeyCaptureFrames), &settings->trace_settings_.trim_ranges, "capture frames");
+    // Trim frame ranges, trim queue submit ranges, and trim frame hotkey are mutually exclusive.
+    // Precedence is frame ranges, queue submit ranges, then frame hotkey.
+    std::string trim_frames = FindOption(options, kOptionKeyCaptureFrames);
+    if (!trim_frames.empty())
+    {
+        ParseUintRangeList(trim_frames, &settings->trace_settings_.trim_ranges, "capture frames");
+        if (!settings->trace_settings_.trim_ranges.empty())
+        {
+            settings->trace_settings_.trim_boundary = TrimBoundary::kFrames;
+        }
+    }
+
+    std::string trim_queue_submits = FindOption(options, kOptionKeyCaptureQueueSubmits);
+    if (!trim_queue_submits.empty())
+    {
+        if (settings->trace_settings_.trim_ranges.empty())
+        {
+            ParseUintRangeList(trim_queue_submits, &settings->trace_settings_.trim_ranges, "capture queue submits");
+            if (!settings->trace_settings_.trim_ranges.empty())
+            {
+                settings->trace_settings_.trim_boundary = TrimBoundary::kQueueSubmits;
+            }
+        }
+        else
+        {
+            GFXRECON_LOG_WARNING(
+                "Settings Loader: Ignoring trim queue submit ranges setting as trim frame ranges has been specified.");
+        }
+    }
+
     std::string trim_key_option        = FindOption(options, kOptionKeyCaptureTrigger);
     std::string trim_key_frames_option = FindOption(options, kOptionKeyCaptureTriggerFrames);
     if (!trim_key_option.empty())
@@ -489,10 +524,14 @@ void CaptureSettings::ProcessOptions(OptionsMap* options, CaptureSettings* setti
             {
                 settings->trace_settings_.trim_key_frames = ParseTrimKeyFramesString(trim_key_frames_option);
             }
+            if (!settings->trace_settings_.trim_key.empty())
+            {
+                settings->trace_settings_.trim_boundary = TrimBoundary::kFrames;
+            }
         }
         else
         {
-            GFXRECON_LOG_WARNING("Settings Loader: Ignore trim key setting as trim ranges has been specified.");
+            GFXRECON_LOG_WARNING("Settings Loader: Ignoring trim key setting as trim ranges has been specified.");
         }
     }
 

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -64,6 +64,13 @@ class CaptureSettings
         kDisabled = 2
     };
 
+    enum class TrimBoundary
+    {
+        kUnknown,
+        kFrames,
+        kQueueSubmits,
+    };
+
     const static char kDefaultCaptureFileName[];
 
     struct ResourveValueAnnotationInfo
@@ -85,6 +92,7 @@ class CaptureSettings
         std::string                  screenshot_dir;
         std::vector<util::UintRange> screenshot_ranges;
         util::ScreenshotFormat       screenshot_format;
+        TrimBoundary                 trim_boundary{ TrimBoundary::kUnknown };
         std::vector<util::UintRange> trim_ranges;
         std::string                  trim_key;
         uint32_t                     trim_key_frames{ 0 };

--- a/framework/encode/capture_settings.h
+++ b/framework/encode/capture_settings.h
@@ -64,12 +64,6 @@ class CaptureSettings
         kDisabled = 2
     };
 
-    struct TrimRange
-    {
-        uint32_t first{ 0 }; // First frame to capture.
-        uint32_t total{ 0 }; // Total number of frames to capture.
-    };
-
     const static char kDefaultCaptureFileName[];
 
     struct ResourveValueAnnotationInfo
@@ -83,33 +77,33 @@ class CaptureSettings
 
     struct TraceSettings
     {
-        std::string                   capture_file{ kDefaultCaptureFileName };
-        format::EnabledOptions        capture_file_options;
-        bool                          time_stamp_file{ true };
-        bool                          force_flush{ false };
-        MemoryTrackingMode            memory_tracking_mode{ kPageGuard };
-        std::string                   screenshot_dir;
-        std::vector<util::FrameRange> screenshot_ranges;
-        util::ScreenshotFormat        screenshot_format;
-        std::vector<TrimRange>        trim_ranges;
-        std::string                   trim_key;
-        uint32_t                      trim_key_frames{ 0 };
-        RuntimeTriggerState           runtime_capture_trigger{ kNotUsed };
-        int                           page_guard_signal_handler_watcher_max_restores{ 1 };
-        bool                          page_guard_copy_on_map{ util::PageGuardManager::kDefaultEnableCopyOnMap };
-        bool                          page_guard_separate_read{ util::PageGuardManager::kDefaultEnableSeparateRead };
-        bool                          page_guard_persistent_memory{ false };
-        bool                          page_guard_align_buffer_sizes{ false };
-        bool                          page_guard_track_ahb_memory{ false };
-        bool                          page_guard_unblock_sigsegv{ false };
-        bool                          page_guard_signal_handler_watcher{ false };
-        bool                          debug_layer{ false };
-        bool                          debug_device_lost{ false };
-        bool                          disable_dxr{ false };
-        uint32_t                      accel_struct_padding{ 0 };
-        bool                          force_command_serialization{ false };
-        bool                          queue_zero_only{ false };
-        bool                          allow_pipeline_compile_required{ false };
+        std::string                  capture_file{ kDefaultCaptureFileName };
+        format::EnabledOptions       capture_file_options;
+        bool                         time_stamp_file{ true };
+        bool                         force_flush{ false };
+        MemoryTrackingMode           memory_tracking_mode{ kPageGuard };
+        std::string                  screenshot_dir;
+        std::vector<util::UintRange> screenshot_ranges;
+        util::ScreenshotFormat       screenshot_format;
+        std::vector<util::UintRange> trim_ranges;
+        std::string                  trim_key;
+        uint32_t                     trim_key_frames{ 0 };
+        RuntimeTriggerState          runtime_capture_trigger{ kNotUsed };
+        int                          page_guard_signal_handler_watcher_max_restores{ 1 };
+        bool                         page_guard_copy_on_map{ util::PageGuardManager::kDefaultEnableCopyOnMap };
+        bool                         page_guard_separate_read{ util::PageGuardManager::kDefaultEnableSeparateRead };
+        bool                         page_guard_persistent_memory{ false };
+        bool                         page_guard_align_buffer_sizes{ false };
+        bool                         page_guard_track_ahb_memory{ false };
+        bool                         page_guard_unblock_sigsegv{ false };
+        bool                         page_guard_signal_handler_watcher{ false };
+        bool                         debug_layer{ false };
+        bool                         debug_device_lost{ false };
+        bool                         disable_dxr{ false };
+        uint32_t                     accel_struct_padding{ 0 };
+        bool                         force_command_serialization{ false };
+        bool                         queue_zero_only{ false };
+        bool                         allow_pipeline_compile_required{ false };
 
         // An optimization for the page_guard memory tracking mode that eliminates the need for shadow memory by
         // overriding vkAllocateMemory so that all host visible allocations use the external memory extension with a
@@ -176,9 +170,8 @@ class CaptureSettings
 
     static util::Log::Severity ParseLogLevelString(const std::string& value_string, util::Log::Severity default_value);
 
-    static void ParseFramesList(const std::string& value_string, std::vector<util::FrameRange>* frames);
-
-    static void ParseTrimRangeString(const std::string& value_string, std::vector<CaptureSettings::TrimRange>* ranges);
+    static void
+    ParseUintRangeList(const std::string& value_string, std::vector<util::UintRange>* frames, const char* option_name);
 
     static std::string ParseTrimKeyString(const std::string& value_string);
 

--- a/framework/encode/d3d12_capture_manager.cpp
+++ b/framework/encode/d3d12_capture_manager.cpp
@@ -1650,12 +1650,16 @@ void D3D12CaptureManager::PreProcess_ID3D12CommandQueue_ExecuteCommandLists(ID3D
             }
         }
     }
+
+    PreQueueSubmit();
 }
 
 void D3D12CaptureManager::PostProcess_ID3D12CommandQueue_ExecuteCommandLists(ID3D12CommandQueue_Wrapper* wrapper,
                                                                              UINT                        num_lists,
                                                                              ID3D12CommandList* const*   lists)
 {
+    PostQueueSubmit();
+
     if ((GetCaptureMode() & kModeTrack) == kModeTrack)
     {
         state_tracker_->TrackExecuteCommandLists(wrapper, num_lists, lists);

--- a/framework/encode/vulkan_capture_manager.cpp
+++ b/framework/encode/vulkan_capture_manager.cpp
@@ -2185,6 +2185,8 @@ void VulkanCaptureManager::PreProcess_vkQueueSubmit(VkQueue             queue,
     GFXRECON_UNREFERENCED_PARAMETER(fence);
 
     QueueSubmitWriteFillMemoryCmd();
+
+    PreQueueSubmit();
 }
 
 void VulkanCaptureManager::PreProcess_vkQueueSubmit2(VkQueue              queue,
@@ -2198,6 +2200,8 @@ void VulkanCaptureManager::PreProcess_vkQueueSubmit2(VkQueue              queue,
     GFXRECON_UNREFERENCED_PARAMETER(fence);
 
     QueueSubmitWriteFillMemoryCmd();
+
+    PreQueueSubmit();
 }
 
 void VulkanCaptureManager::QueueSubmitWriteFillMemoryCmd()

--- a/framework/encode/vulkan_capture_manager.h
+++ b/framework/encode/vulkan_capture_manager.h
@@ -886,6 +886,8 @@ class VulkanCaptureManager : public CaptureManager
     void
     PostProcess_vkQueueSubmit(VkResult result, VkQueue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence)
     {
+        PostQueueSubmit();
+
         if (((GetCaptureMode() & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
         {
             assert((state_tracker_ != nullptr) && ((submitCount == 0) || (pSubmits != nullptr)));
@@ -905,6 +907,8 @@ class VulkanCaptureManager : public CaptureManager
     void PostProcess_vkQueueSubmit2(
         VkResult result, VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence)
     {
+        PostQueueSubmit();
+
         if (((GetCaptureMode() & kModeTrack) == kModeTrack) && (result == VK_SUCCESS))
         {
             assert((state_tracker_ != nullptr) && ((submitCount == 0) || (pSubmits != nullptr)));

--- a/framework/util/options.h
+++ b/framework/util/options.h
@@ -33,13 +33,13 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(util)
 
-struct FrameRange
+struct UintRange
 {
     uint32_t first{ 0 };
     uint32_t last{ 0 };
 };
 
-std::vector<FrameRange> GetFrameRanges(const std::string& args);
+std::vector<UintRange> GetUintRanges(const char* args, const char* option_name);
 
 enum class ScreenshotFormat : uint32_t
 {

--- a/tools/tool_settings.h
+++ b/tools/tool_settings.h
@@ -481,7 +481,8 @@ GetScreenshotRanges(const gfxrecon::util::ArgumentParser& arg_parser)
 
         if (!value.empty())
         {
-            std::vector<gfxrecon::util::FrameRange> frame_ranges = gfxrecon::util::GetFrameRanges(value);
+            std::vector<gfxrecon::util::UintRange> frame_ranges =
+                gfxrecon::util::GetUintRanges(value.c_str(), "screenshot frames");
 
             for (uint32_t i = 0; i < frame_ranges.size(); ++i)
             {


### PR DESCRIPTION
Enable trimming based on a range of GPU queue submissions--vkQueueSubmit
for Vulkan, ExecuteCommandLists for DX12. Trimming is activated immediately
before the first submission and deactivated immediately after the last
submission in the range(s) specified.