### PR TITLE
dx12 dump: Add TEST_AVAILABLE_ARGS

### DIFF
--- a/framework/decode/dx12_browse_consumer.h
+++ b/framework/decode/dx12_browse_consumer.h
@@ -29,14 +29,19 @@
 GFXRECON_BEGIN_NAMESPACE(gfxrecon)
 GFXRECON_BEGIN_NAMESPACE(decode)
 
+// If TEST_AVAILABLE_ARGS is enabled, it finds the available args that follow the original args, if the original args
+// are unavailable.
+const bool TEST_AVAILABLE_ARGS = false;
+
 struct TrackDumpDrawcall
 {
-    format::HandleId command_list_id{ format::kNullHandleId };
-    uint64_t         begin_code_index{ 0 };
-    uint64_t         close_code_index{ 0 };
-    uint64_t         begin_renderpass_code_index{ 0 };
-    uint64_t         set_render_targets_code_index{ 0 };
-    format::HandleId root_signature_handle_id{ format::kNullHandleId };
+    DumpResourcesTarget dump_resources_target{};
+    format::HandleId    command_list_id{ format::kNullHandleId };
+    uint64_t            begin_code_index{ 0 };
+    uint64_t            close_code_index{ 0 };
+    uint64_t            begin_renderpass_code_index{ 0 };
+    uint64_t            set_render_targets_code_index{ 0 };
+    format::HandleId    root_signature_handle_id{ format::kNullHandleId };
 
     // vertex
     std::vector<D3D12_VERTEX_BUFFER_VIEW> captured_vertex_buffer_views;
@@ -118,6 +123,11 @@ class Dx12BrowseConsumer : public Dx12Consumer
             GFXRECON_LOG_FATAL("The target submit index(%d) of dump resources is out of range(%d).",
                                dump_resources_target_.submit_index,
                                track_submit_index_);
+            if (TEST_AVAILABLE_ARGS)
+            {
+                GFXRECON_LOG_FATAL("Although TEST_AVAILABLE_ARGS is enabled, it cann't find the available args that "
+                                   "follow the original args.");
+            }
             GFXRECON_ASSERT(track_submit_index_ > dump_resources_target_.submit_index);
         }
 
@@ -127,7 +137,17 @@ class Dx12BrowseConsumer : public Dx12Consumer
             auto drawcall_size = it->second.track_dump_drawcalls.size();
             GFXRECON_ASSERT(drawcall_size > dump_resources_target_.drawcall_index);
 
-            return &(it->second.track_dump_drawcalls[dump_resources_target_.drawcall_index]);
+            if (is_modified_args)
+            {
+                GFXRECON_LOG_INFO("TEST_AVAILABLE_ARGS is enabled, it finds the available args(%d,%d,%d) that follow "
+                                  "the original args.",
+                                  dump_resources_target_.submit_index,
+                                  dump_resources_target_.command_index,
+                                  dump_resources_target_.drawcall_index);
+            }
+            auto& target                 = it->second.track_dump_drawcalls[dump_resources_target_.drawcall_index];
+            target.dump_resources_target = dump_resources_target_;
+            return &target;
         }
         return nullptr;
     }
@@ -393,10 +413,22 @@ class Dx12BrowseConsumer : public Dx12Consumer
             {
                 if (NumCommandLists <= dump_resources_target_.command_index)
                 {
-                    GFXRECON_LOG_FATAL("The target command index(%d) of dump resources is out of range(%d).",
-                                       dump_resources_target_.command_index,
-                                       NumCommandLists);
-                    GFXRECON_ASSERT(NumCommandLists > dump_resources_target_.command_index);
+                    if (TEST_AVAILABLE_ARGS)
+                    {
+                        ++track_submit_index_;
+                        ++dump_resources_target_.submit_index;
+                        dump_resources_target_.command_index  = 0;
+                        dump_resources_target_.drawcall_index = 0;
+                        is_modified_args                      = true;
+                        return;
+                    }
+                    else
+                    {
+                        GFXRECON_LOG_FATAL("The target command index(%d) of dump resources is out of range(%d).",
+                                           dump_resources_target_.command_index,
+                                           NumCommandLists);
+                        GFXRECON_ASSERT(NumCommandLists > dump_resources_target_.command_index);
+                    }
                 }
                 auto command_lists   = ppCommandLists->GetPointer();
                 target_command_list_ = command_lists[dump_resources_target_.command_index];
@@ -407,10 +439,40 @@ class Dx12BrowseConsumer : public Dx12Consumer
                 auto drawcall_size = it->second.track_dump_drawcalls.size();
                 if (drawcall_size <= dump_resources_target_.drawcall_index)
                 {
-                    GFXRECON_LOG_FATAL("The target drawcall index(%d) of dump resources is out of range(%d).",
-                                       dump_resources_target_.drawcall_index,
-                                       drawcall_size);
-                    GFXRECON_ASSERT(drawcall_size > dump_resources_target_.drawcall_index);
+                    if (TEST_AVAILABLE_ARGS)
+                    {
+                        is_modified_args = true;
+                        while (true)
+                        {
+                            ++dump_resources_target_.command_index;
+                            if (NumCommandLists <= dump_resources_target_.command_index)
+                            {
+                                target_command_list_ = format::kNullHandleId;
+                                ++track_submit_index_;
+                                ++dump_resources_target_.submit_index;
+                                dump_resources_target_.command_index  = 0;
+                                dump_resources_target_.drawcall_index = 0;
+                                return;
+                            }
+                            target_command_list_ = command_lists[dump_resources_target_.command_index];
+
+                            it = track_commandlist_infos_.find(target_command_list_);
+                            GFXRECON_ASSERT(it != track_commandlist_infos_.end());
+
+                            drawcall_size = it->second.track_dump_drawcalls.size();
+                            if (drawcall_size <= dump_resources_target_.drawcall_index)
+                            {
+                                continue;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        GFXRECON_LOG_FATAL("The target drawcall index(%d) of dump resources is out of range(%d).",
+                                           dump_resources_target_.drawcall_index,
+                                           drawcall_size);
+                        GFXRECON_ASSERT(drawcall_size > dump_resources_target_.drawcall_index);
+                    }
                 }
                 it->second.track_dump_drawcalls[dump_resources_target_.drawcall_index].execute_code_index =
                     call_info.index;
@@ -422,6 +484,7 @@ class Dx12BrowseConsumer : public Dx12Consumer
     virtual bool IsComplete(uint64_t block_index) override { return (target_command_list_ != format::kNullHandleId); }
 
   private:
+    bool                is_modified_args{ false };
     DumpResourcesTarget dump_resources_target_{};
     uint32_t            track_submit_index_{ 0 };
     format::HandleId    target_command_list_{ 0 };

--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -374,7 +374,7 @@ struct ResourceStatesOrder
 {
     D3D12_RESOURCE_TRANSITION_BARRIER transition;
     D3D12_RESOURCE_BARRIER_FLAGS      barrier_flags;
-    uint64_t                          code_index{ 0 };
+    uint64_t                          block_index{ 0 };
 };
 
 struct D3D12CommandListInfo : DxObjectExtraInfo

--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -383,6 +383,8 @@ struct D3D12CommandListInfo : DxObjectExtraInfo
     static constexpr char             kObjectType[] = "ID3D12CommandListInfo";
     D3D12CommandListInfo() : DxObjectExtraInfo(kType) {}
 
+    D3D12_COMMAND_LIST_TYPE create_list_type{ D3D12_COMMAND_LIST_TYPE_NONE };
+
     bool requires_sync_after_execute{ false };
 
     // Tracked state used by Dx12ResourceValueMapper.

--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -103,14 +103,6 @@ Dx12ReplayConsumerBase::Dx12ReplayConsumerBase(std::shared_ptr<application::Appl
         InitializeScreenshotHandler();
     }
 
-    if (options.enable_dump_resources)
-    {
-        gfxrecon::graphics::Dx12DumpResourcesConfig config;
-        config.captured_file_name    = options.filename;
-        config.dump_resources_target = options.dump_resources_target;
-        dump_resources_              = gfxrecon::graphics::Dx12DumpResources::Create(config);
-    }
-
     DetectAdapters();
 
     auto get_object_func = std::bind(&Dx12ReplayConsumerBase::GetObjectInfo, this, std::placeholders::_1);
@@ -2037,7 +2029,7 @@ void Dx12ReplayConsumerBase::OverrideExecuteCommandLists(DxObjectInfo*          
             for (uint32_t i = 0; i < num_command_lists; ++i)
             {
                 front_command_list_ids.emplace_back(command_list_ids[i]);
-                if (i == options_.dump_resources_target.command_index)
+                if (i == track_dump_resources_.target.dump_resources_target.command_index)
                 {
                     is_complete = true;
                     modified_command_lists.emplace_back(track_dump_resources_.split_command_sets[0].list);
@@ -5929,16 +5921,21 @@ Dx12ReplayConsumerBase::CreateCopyResourceAsyncReadQueueSyncEvent(ID3D12Fence*  
 
 void Dx12ReplayConsumerBase::WriteDumpResources(DxObjectInfo* queue_object_info)
 {
+    gfxrecon::graphics::Dx12DumpResourcesConfig config;
+    config.captured_file_name                                   = options_.filename;
+    config.dump_resources_target                                = options_.dump_resources_target;
+    std::unique_ptr<graphics::Dx12DumpResources> dump_resources = gfxrecon::graphics::Dx12DumpResources::Create(config);
+
     auto queue_extra_info = GetExtraInfo<D3D12CommandQueueInfo>(queue_object_info);
     if (queue_extra_info->pending_events.empty())
     {
-        dump_resources_->WriteResources(track_dump_resources_);
+        dump_resources->WriteResources(track_dump_resources_);
         track_dump_resources_.Clear();
     }
     else
     {
         auto queue_sync_event = QueueSyncEventInfo{ false, false, nullptr, 0, [&]() {
-                                                       dump_resources_->WriteResources(track_dump_resources_);
+                                                       dump_resources->WriteResources(track_dump_resources_);
                                                        track_dump_resources_.Clear();
                                                    } };
 

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -1052,7 +1052,6 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
     util::ScreenshotFormat                                screenshot_format_;
     std::unique_ptr<ScreenshotHandlerBase>                screenshot_handler_;
     std::unordered_map<ID3D12Resource*, ResourceInitInfo> resource_init_infos_;
-    std::unique_ptr<graphics::Dx12DumpResources>          dump_resources_;
     graphics::TrackDumpResources                          track_dump_resources_;
 
     std::vector<graphics::dx12::ID3D12ResourceComPtr> dump_resources_staging_buffers_;

--- a/framework/decode/dx12_resource_value_mapper.cpp
+++ b/framework/decode/dx12_resource_value_mapper.cpp
@@ -540,10 +540,13 @@ void Dx12ResourceValueMapper::PostProcessCreateRootSignature(PointerDecoder<uint
     GFXRECON_ASSERT(blob_with_root_signature != nullptr);
     GFXRECON_ASSERT(blob_length_in_bytes != 0);
 
-    auto versioned_root_sig =
-        graphics::dx12::GetUnconvertedRootSignatureDesc(blob_with_root_signature, blob_length_in_bytes);
-    if (versioned_root_sig)
+    graphics::dx12::ID3D12VersionedRootSignatureDeserializerComPtr root_sig_deserializer{ nullptr };
+    HRESULT result = D3D12CreateVersionedRootSignatureDeserializer(
+        blob_with_root_signature, blob_length_in_bytes, IID_PPV_ARGS(&root_sig_deserializer));
+    if (SUCCEEDED(result))
     {
+        auto versioned_root_sig = root_sig_deserializer->GetUnconvertedRootSignatureDesc();
+
         switch (versioned_root_sig->Version)
         {
             case D3D_ROOT_SIGNATURE_VERSION_1_0:

--- a/framework/graphics/dx12_dump_resources.cpp
+++ b/framework/graphics/dx12_dump_resources.cpp
@@ -100,7 +100,10 @@ void Dx12DumpResources::WriteResource(nlohmann::ordered_json& jdata,
 
 void Dx12DumpResources::WriteResources(const TrackDumpResources& resources)
 {
-    WriteMetaCommandToFile("resources", [&](auto& jdata) {
+    WriteDrawCallCommandToFile([&](auto& jdata) {
+        util::FieldToJson(jdata["block_index"], resources.target.drawcall_block_index, json_options_);
+        util::FieldToJson(jdata["execute_block_index"], resources.target.execute_block_index, json_options_);
+
         // vertex
         WriteResources(jdata["vertex"], json_options_.data_sub_dir, resources.copy_vertex_resources);
 

--- a/framework/graphics/dx12_dump_resources.cpp
+++ b/framework/graphics/dx12_dump_resources.cpp
@@ -122,7 +122,7 @@ void Dx12DumpResources::WriteResources(const TrackDumpResources& resources)
             uint32_t uav_index = 0;
             for (const auto& uav_data : heap_data.copy_unordered_accesses)
             {
-                WriteResource(jdata_sub["unordered_access"][uav_index]["reousrce"], filename, uav_data.resource);
+                WriteResource(jdata_sub["unordered_access"][uav_index]["resource"], filename, uav_data.resource);
                 WriteResource(
                     jdata_sub["unordered_access"][uav_index]["counter_resource"], filename, uav_data.counter_resource);
                 ++uav_index;

--- a/framework/graphics/dx12_dump_resources.h
+++ b/framework/graphics/dx12_dump_resources.h
@@ -190,19 +190,18 @@ class Dx12DumpResources
     void WriteBlockStart();
     void WriteBlockEnd();
 
-    constexpr const char* NameMeta() const { return "meta"; }
+    constexpr const char* NameDrawCall() const { return "drawcall"; }
     constexpr const char* NameName() const { return "name"; }
     constexpr const char* NameArgs() const { return "args"; }
 
     template <typename ToJsonFunctionType>
-    inline void WriteMetaCommandToFile(const std::string& command_name, ToJsonFunctionType to_json_function)
+    inline void WriteDrawCallCommandToFile(ToJsonFunctionType to_json_function)
     {
         using namespace util;
         WriteBlockStart();
 
-        nlohmann::ordered_json& meta = json_data_[NameMeta()];
-        meta[NameName()]             = command_name;
-        to_json_function(meta[NameArgs()]);
+        nlohmann::ordered_json& draw_call = json_data_[NameDrawCall()];
+        to_json_function(draw_call);
 
         WriteBlockEnd();
     }

--- a/framework/graphics/dx12_util.h
+++ b/framework/graphics/dx12_util.h
@@ -279,19 +279,6 @@ void RobustGetCopyableFootprint(ID3D12Device*                       device,
                                 UINT64*                             pRowSizeInBytes,
                                 UINT64*                             pTotalBytes);
 
-inline const D3D12_VERSIONED_ROOT_SIGNATURE_DESC* GetUnconvertedRootSignatureDesc(uint8_t* blob_with_root_signature,
-                                                                                  SIZE_T   blob_length_in_bytes)
-{
-    graphics::dx12::ID3D12VersionedRootSignatureDeserializerComPtr root_sig_deserializer{ nullptr };
-    HRESULT result = D3D12CreateVersionedRootSignatureDeserializer(
-        blob_with_root_signature, blob_length_in_bytes, IID_PPV_ARGS(&root_sig_deserializer));
-    if (SUCCEEDED(result))
-    {
-        return root_sig_deserializer->GetUnconvertedRootSignatureDesc();
-    }
-    return nullptr;
-}
-
 GFXRECON_END_NAMESPACE(dx12)
 GFXRECON_END_NAMESPACE(graphics)
 GFXRECON_END_NAMESPACE(gfxrecon)


### PR DESCRIPTION
1.  If TEST_AVAILABLE_ARGS is enabled, it finds the available args that follow the original args, if the original args are unavailable.

2. dx12 dump: Bugfix
    1. Record the type of CommandLists. The split command lists' type has to be
    the same to the original type.

    2. Remove dx12_util.h GetUnconvertedRootSignatureDesc. The return is
    pointer from the system. The memory could be released anytime. Use
    GetUnconvertedRootSignatureDesc straightforward.
    
 3. Rename meta to drawcall and code_index to block_index.