### PR TITLE
Fix wrong command list type

### DIFF
--- a/framework/decode/dx12_object_info.h
+++ b/framework/decode/dx12_object_info.h
@@ -221,6 +221,7 @@ struct D3D12CommandQueueInfo : DxObjectExtraInfo
     graphics::dx12::ID3D12FenceComPtr sync_fence;
     uint64_t                          sync_value{ 0 };
     HANDLE                            sync_event{ nullptr };
+    D3D12_COMMAND_LIST_TYPE           create_type{ D3D12_COMMAND_LIST_TYPE_NONE };
 
     // Synchronization used for mapping values in resource data.
     graphics::dx12::ID3D12FenceComPtr resource_value_map_fence{ nullptr };

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -358,7 +358,9 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     void ProcessDxgiAdapterInfo(const format::DxgiAdapterInfoCommandHeader& adapter_info_header);
 
-    void InitCommandQueueExtraInfo(ID3D12Device* device, HandlePointerDecoder<void*>* command_queue_decoder);
+    void InitCommandQueueExtraInfo(ID3D12Device*                   device,
+                                   HandlePointerDecoder<void*>*    command_queue_decoder,
+                                   const D3D12_COMMAND_QUEUE_DESC& dec);
 
     HRESULT OverrideCreateCommandQueue(DxObjectInfo*                                           replay_object_info,
                                        HRESULT                                                 original_result,
@@ -1026,7 +1028,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     bool CopyResourceAsyncQueue(const std::vector<format::HandleId>& front_command_list_ids,
                                 graphics::CopyResourceData&          copy_resource_data,
-                                ID3D12CommandQueue*                  queue,
+                                DxObjectInfo*                        queue_object_info,
                                 ID3D12Fence*                         fence,
                                 UINT64                               fence_signal_value,
                                 UINT64                               fence_wait_value);


### PR DESCRIPTION
Test code: https://github.com/microsoft/DirectX-Graphics-Samples/tree/master/Samples/Desktop/D3D12ExecuteIndirect  
arg: `--dump-resource 1,0,0`

1. Command allocator and command list's type have to be the same to the type of queue, or it gets error `ID3D12CommandQueue::ExecuteCommandLists: Command lists must have matching type to queue`. It causes device lost, so record the queue type for creating command allocator and command list.

2. For Compute command list type, some resource states are not available, It gets error `ID3D12CommandList::ResourceBarrier: D3D12_RESOURCE_STATES has invalid flags (0x82) for compute command list`. It also cause device lost, so remove those states. It might have more unavailable states that should be removed.

However, this's not a good idea. It causes more wrong resource states, although it avoids crush. A better way might be that using a new direct type queue to copy resources. But it has two issues. 1: If the resource is swapchain, it has to use its queue. 2: It has to deal with sync thing between the new queue and the original queue.

It's not a perfect solution, so please let me know if you have a better idea.