### PR TITLE
Reduce memory use

### DIFF
--- a/framework/decode/dx12_replay_consumer_base.cpp
+++ b/framework/decode/dx12_replay_consumer_base.cpp
@@ -4464,6 +4464,11 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                     {
                         mip_size = mip_count;
                     }
+                    auto array_size = view.ArraySize;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
                     if (view.MostDetailedMip != 0)
                     {
                         if (mip_size == -1)
@@ -4474,7 +4479,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                                                                                    mip_size,
                                                                                    mip_count,
                                                                                    view.FirstArraySlice,
-                                                                                   view.ArraySize,
+                                                                                   array_size,
                                                                                    array_count,
                                                                                    0);
                     }
@@ -4485,7 +4490,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                                                                                    mip_size,
                                                                                    mip_count,
                                                                                    view.FirstArraySlice,
-                                                                                   view.ArraySize,
+                                                                                   array_size,
                                                                                    array_count,
                                                                                    0);
                     }
@@ -4524,6 +4529,11 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                     {
                         mip_size = mip_count;
                     }
+                    auto array_size = view.ArraySize;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
                     if (view.MostDetailedMip != 0)
                     {
                         if (mip_size == -1)
@@ -4534,7 +4544,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                                                                                    mip_size,
                                                                                    mip_count,
                                                                                    view.FirstArraySlice,
-                                                                                   view.ArraySize,
+                                                                                   array_size,
                                                                                    array_count,
                                                                                    view.PlaneSlice);
                     }
@@ -4545,7 +4555,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                                                                                    mip_size,
                                                                                    mip_count,
                                                                                    view.FirstArraySlice,
-                                                                                   view.ArraySize,
+                                                                                   array_size,
                                                                                    array_count,
                                                                                    view.PlaneSlice);
                     }
@@ -4558,9 +4568,14 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                 }
                 case D3D12_SRV_DIMENSION_TEXTURE2DMSARRAY:
                 {
-                    auto view                = info.view.Texture2DMSArray;
+                    auto view       = info.view.Texture2DMSArray;
+                    auto array_size = view.ArraySize;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
                     info.subresource_indices = GetDescriptorSubresourceIndices(
-                        0, 1, mip_count, view.FirstArraySlice, view.ArraySize, array_count, 0);
+                        0, 1, mip_count, view.FirstArraySlice, array_size, array_count, 0);
                     break;
                 }
                 case D3D12_SRV_DIMENSION_TEXTURE3D:
@@ -4620,6 +4635,11 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                     {
                         mip_size = mip_count;
                     }
+                    auto array_size = view.NumCubes;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
                     if (view.MostDetailedMip != 0)
                     {
                         if (mip_size == -1)
@@ -4630,7 +4650,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                                                                                    mip_size,
                                                                                    mip_count,
                                                                                    view.First2DArrayFace,
-                                                                                   view.NumCubes,
+                                                                                   array_size,
                                                                                    array_count,
                                                                                    0);
                     }
@@ -4640,7 +4660,7 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateShaderResourceView(
                                                                                    mip_size,
                                                                                    mip_count,
                                                                                    view.First2DArrayFace,
-                                                                                   view.NumCubes,
+                                                                                   array_size,
                                                                                    array_count,
                                                                                    0);
                     }
@@ -4696,40 +4716,48 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateUnorderedAccessView(
                         info.view.Texture1D.MipSlice, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 case D3D12_UAV_DIMENSION_TEXTURE1DARRAY:
-                    info.subresource_indices = GetDescriptorSubresourceIndices(info.view.Texture1DArray.MipSlice,
-                                                                               1,
-                                                                               mip_count,
-                                                                               info.view.Texture1DArray.FirstArraySlice,
-                                                                               info.view.Texture1DArray.ArraySize,
-                                                                               array_count,
-                                                                               0);
+                {
+                    auto view       = info.view.Texture1DArray;
+                    auto array_size = view.ArraySize;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
+                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                        view.MipSlice, 1, mip_count, view.FirstArraySlice, array_size, array_count, 0);
                     break;
+                }
                 case D3D12_UAV_DIMENSION_TEXTURE2D:
                     info.subresource_indices = GetDescriptorSubresourceIndices(
                         info.view.Texture2D.MipSlice, 1, mip_count, 0, 1, array_count, info.view.Texture2D.PlaneSlice);
                     break;
                 case D3D12_UAV_DIMENSION_TEXTURE2DARRAY:
-                    info.subresource_indices = GetDescriptorSubresourceIndices(info.view.Texture2DArray.MipSlice,
-                                                                               1,
-                                                                               mip_count,
-                                                                               info.view.Texture2DArray.FirstArraySlice,
-                                                                               info.view.Texture2DArray.ArraySize,
-                                                                               array_count,
-                                                                               info.view.Texture2DArray.PlaneSlice);
+                {
+                    auto view       = info.view.Texture2DArray;
+                    auto array_size = view.ArraySize;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
+                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                        view.MipSlice, 1, mip_count, view.FirstArraySlice, array_size, array_count, view.PlaneSlice);
                     break;
+                }
                 case D3D12_UAV_DIMENSION_TEXTURE2DMS:
                     info.subresource_indices = GetDescriptorSubresourceIndices(0, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 case D3D12_UAV_DIMENSION_TEXTURE2DMSARRAY:
-                    info.subresource_indices =
-                        GetDescriptorSubresourceIndices(0,
-                                                        1,
-                                                        mip_count,
-                                                        info.view.Texture2DMSArray.FirstArraySlice,
-                                                        info.view.Texture2DMSArray.ArraySize,
-                                                        array_count,
-                                                        0);
+                {
+                    auto view       = info.view.Texture2DMSArray;
+                    auto array_size = view.ArraySize;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
+                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                        0, 1, mip_count, view.FirstArraySlice, array_size, array_count, 0);
                     break;
+                }
                 case D3D12_UAV_DIMENSION_TEXTURE3D:
                 {
                     // DUMPTODO: handle FirstWSlice and WSize
@@ -4785,40 +4813,48 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateRenderTargetView(
                         info.view.Texture1D.MipSlice, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 case D3D12_RTV_DIMENSION_TEXTURE1DARRAY:
-                    info.subresource_indices = GetDescriptorSubresourceIndices(info.view.Texture1DArray.MipSlice,
-                                                                               1,
-                                                                               mip_count,
-                                                                               info.view.Texture1DArray.FirstArraySlice,
-                                                                               info.view.Texture1DArray.ArraySize,
-                                                                               array_count,
-                                                                               0);
+                {
+                    auto view       = info.view.Texture1DArray;
+                    auto array_size = view.ArraySize;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
+                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                        view.MipSlice, 1, mip_count, view.FirstArraySlice, array_size, array_count, 0);
                     break;
+                }
                 case D3D12_RTV_DIMENSION_TEXTURE2D:
                     info.subresource_indices = GetDescriptorSubresourceIndices(
                         info.view.Texture2D.MipSlice, 1, mip_count, 0, 1, array_count, info.view.Texture2D.PlaneSlice);
                     break;
                 case D3D12_RTV_DIMENSION_TEXTURE2DARRAY:
-                    info.subresource_indices = GetDescriptorSubresourceIndices(info.view.Texture2DArray.MipSlice,
-                                                                               1,
-                                                                               mip_count,
-                                                                               info.view.Texture2DArray.FirstArraySlice,
-                                                                               info.view.Texture2DArray.ArraySize,
-                                                                               array_count,
-                                                                               info.view.Texture2DArray.PlaneSlice);
+                {
+                    auto view       = info.view.Texture2DArray;
+                    auto array_size = view.ArraySize;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
+                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                        view.MipSlice, 1, mip_count, view.FirstArraySlice, array_size, array_count, view.PlaneSlice);
                     break;
+                }
                 case D3D12_RTV_DIMENSION_TEXTURE2DMS:
                     info.subresource_indices = GetDescriptorSubresourceIndices(0, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 case D3D12_RTV_DIMENSION_TEXTURE2DMSARRAY:
-                    info.subresource_indices =
-                        GetDescriptorSubresourceIndices(0,
-                                                        1,
-                                                        mip_count,
-                                                        info.view.Texture2DMSArray.FirstArraySlice,
-                                                        info.view.Texture2DMSArray.ArraySize,
-                                                        array_count,
-                                                        0);
+                {
+                    auto view       = info.view.Texture2DMSArray;
+                    auto array_size = view.ArraySize;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
+                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                        0, 1, mip_count, view.FirstArraySlice, array_size, array_count, 0);
                     break;
+                }
                 case D3D12_RTV_DIMENSION_TEXTURE3D:
                 {
                     // DUMPTODO: Handle FirstWSlice and WSize
@@ -4871,40 +4907,48 @@ void Dx12ReplayConsumerBase::PostCall_ID3D12Device_CreateDepthStencilView(
                         info.view.Texture1D.MipSlice, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 case D3D12_DSV_DIMENSION_TEXTURE1DARRAY:
-                    info.subresource_indices = GetDescriptorSubresourceIndices(info.view.Texture1DArray.MipSlice,
-                                                                               1,
-                                                                               mip_count,
-                                                                               info.view.Texture1DArray.FirstArraySlice,
-                                                                               info.view.Texture1DArray.ArraySize,
-                                                                               array_count,
-                                                                               0);
+                {
+                    auto view       = info.view.Texture1DArray;
+                    auto array_size = view.ArraySize;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
+                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                        view.MipSlice, 1, mip_count, view.FirstArraySlice, array_size, array_count, 0);
                     break;
+                }
                 case D3D12_DSV_DIMENSION_TEXTURE2D:
                     info.subresource_indices = GetDescriptorSubresourceIndices(
                         info.view.Texture2D.MipSlice, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 case D3D12_DSV_DIMENSION_TEXTURE2DARRAY:
-                    info.subresource_indices = GetDescriptorSubresourceIndices(info.view.Texture2DArray.MipSlice,
-                                                                               1,
-                                                                               mip_count,
-                                                                               info.view.Texture2DArray.FirstArraySlice,
-                                                                               info.view.Texture2DArray.ArraySize,
-                                                                               array_count,
-                                                                               0);
+                {
+                    auto view       = info.view.Texture2DArray;
+                    auto array_size = view.ArraySize;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
+                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                        view.MipSlice, 1, mip_count, view.FirstArraySlice, array_size, array_count, 0);
                     break;
+                }
                 case D3D12_DSV_DIMENSION_TEXTURE2DMS:
                     info.subresource_indices = GetDescriptorSubresourceIndices(0, 1, mip_count, 0, 1, array_count, 0);
                     break;
                 case D3D12_DSV_DIMENSION_TEXTURE2DMSARRAY:
-                    info.subresource_indices =
-                        GetDescriptorSubresourceIndices(0,
-                                                        1,
-                                                        mip_count,
-                                                        info.view.Texture2DMSArray.FirstArraySlice,
-                                                        info.view.Texture2DMSArray.ArraySize,
-                                                        array_count,
-                                                        0);
+                {
+                    auto view       = info.view.Texture2DMSArray;
+                    auto array_size = view.ArraySize;
+                    if (array_size == -1)
+                    {
+                        array_size = array_count;
+                    }
+                    info.subresource_indices = GetDescriptorSubresourceIndices(
+                        0, 1, mip_count, view.FirstArraySlice, array_size, array_count, 0);
                     break;
+                }
                 case D3D12_DSV_DIMENSION_UNKNOWN:
                 default:
                     GFXRECON_LOG_ERROR("Unknown D3D12_DSV_DIMENSION.");

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -998,33 +998,36 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     std::wstring ConstructObjectName(format::HandleId capture_id, format::ApiCallId call_id);
 
-    void CopyResourcesForBeforeDrawcall(DxObjectInfo*                        queue_object_info,
-                                        const std::vector<format::HandleId>& front_command_list_ids);
+    void InitializeDumpResources();
 
-    void CopyResourceForBeforeDrawcallByGPUVA(DxObjectInfo*                        queue_object_info,
-                                              const std::vector<format::HandleId>& front_command_list_ids,
-                                              D3D12_GPU_VIRTUAL_ADDRESS            capture_source_gpu_va,
-                                              uint64_t                             source_size,
-                                              graphics::CopyResourceData&          copy_resource_data);
+    void CopyDrawcallResources(DxObjectInfo*                        queue_object_info,
+                               const std::vector<format::HandleId>& front_command_list_ids,
+                               const std::string&                   write_type);
 
-    void CopyResourceForBeforeDrawcall(DxObjectInfo*                        queue_object_info,
-                                       const std::vector<format::HandleId>& front_command_list_ids,
-                                       format::HandleId                     source_resource_id,
-                                       uint64_t                             source_offset,
-                                       uint64_t                             source_size,
-                                       graphics::CopyResourceData&          copy_resource_data);
+    void CopyDrawcallResourceByGPUVA(DxObjectInfo*                                       queue_object_info,
+                                     const std::vector<format::HandleId>&                front_command_list_ids,
+                                     D3D12_GPU_VIRTUAL_ADDRESS                           capture_source_gpu_va,
+                                     uint64_t                                            source_size,
+                                     const std::vector<std::pair<std::string, int32_t>>& json_path,
+                                     const std::string&                                  file_name,
+                                     const std::string&                                  write_type);
 
-    void CopyResourcesForAfterDrawcall(DxObjectInfo*                        queue_object_info,
-                                       const std::vector<format::HandleId>& front_command_list_ids);
+    void CopyDrawcallResource(DxObjectInfo*                                       queue_object_info,
+                              const std::vector<format::HandleId>&                front_command_list_ids,
+                              format::HandleId                                    source_resource_id,
+                              uint64_t                                            source_offset,
+                              uint64_t                                            source_size,
+                              const std::vector<uint32_t>&                        subresource_indices,
+                              const std::vector<std::pair<std::string, int32_t>>& json_path,
+                              const std::string&                                  file_name,
+                              const std::string&                                  write_type);
 
-    // source_resource_id have been saved in CopyResourceData in CopyResourcesForBeforeDrawcall.
-    void CopyResourcesForAfterDrawcall(DxObjectInfo*                            queue_object_info,
-                                       const std::vector<format::HandleId>&     front_command_list_ids,
-                                       std::vector<graphics::CopyResourceData>& copy_resource_datas);
-
-    void CopyResourceForAfterDrawcall(DxObjectInfo*                        queue_object_info,
-                                      const std::vector<format::HandleId>& front_command_list_ids,
-                                      graphics::CopyResourceData&          copy_resource_data);
+    void CopyDrawcallResource(DxObjectInfo*                        queue_object_info,
+                              const std::vector<format::HandleId>& front_command_list_ids,
+                              format::HandleId                     source_resource_id,
+                              uint64_t                             source_offset,
+                              uint64_t                             source_size,
+                              graphics::CopyResourceData&          copy_resource_data);
 
     bool CopyResourceAsyncQueue(const std::vector<format::HandleId>& front_command_list_ids,
                                 graphics::CopyResourceData&          copy_resource_data,
@@ -1051,8 +1054,6 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
                                                                  HANDLE                             fence_event,
                                                                  graphics::CopyResourceData*        copy_resource_data,
                                                                  std::vector<std::vector<uint8_t>>* subresource_datas);
-
-    void WriteDumpResources(DxObjectInfo* queue_object_info);
 
     std::unique_ptr<graphics::DX12ImageRenderer>          frame_buffer_renderer_;
     Dx12ObjectInfoTable                                   object_info_table_;
@@ -1088,6 +1089,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
     std::unordered_map<ID3D12Resource*, ResourceInitInfo> resource_init_infos_;
     graphics::TrackDumpResources                          track_dump_resources_;
 
+    std::unique_ptr<graphics::Dx12DumpResources>      dump_resources_{ nullptr };
     std::vector<graphics::dx12::ID3D12ResourceComPtr> dump_resources_staging_buffers_;
     std::vector<uint64_t>                             dump_resources_staging_buffer_sizes_;
 };

--- a/framework/decode/dx12_replay_consumer_base.h
+++ b/framework/decode/dx12_replay_consumer_base.h
@@ -998,7 +998,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
 
     std::wstring ConstructObjectName(format::HandleId capture_id, format::ApiCallId call_id);
 
-    void InitializeDumpResources();
+    void InitializeDumpResources(ID3D12Device* device);
 
     void CopyDrawcallResources(DxObjectInfo*                        queue_object_info,
                                const std::vector<format::HandleId>& front_command_list_ids,
@@ -1089,9 +1089,7 @@ class Dx12ReplayConsumerBase : public Dx12Consumer
     std::unordered_map<ID3D12Resource*, ResourceInitInfo> resource_init_infos_;
     graphics::TrackDumpResources                          track_dump_resources_;
 
-    std::unique_ptr<graphics::Dx12DumpResources>      dump_resources_{ nullptr };
-    std::vector<graphics::dx12::ID3D12ResourceComPtr> dump_resources_staging_buffers_;
-    std::vector<uint64_t>                             dump_resources_staging_buffer_sizes_;
+    std::unique_ptr<graphics::Dx12DumpResources> dump_resources_{ nullptr };
 };
 
 GFXRECON_END_NAMESPACE(decode)

--- a/framework/format/format.h
+++ b/framework/format/format.h
@@ -62,6 +62,7 @@ const size_t   kUuidSize                  = 16;
 const size_t   kMaxPhysicalDeviceNameSize = 256;
 const HandleId kNullHandleId              = 0;
 const size_t   kAdapterDescriptionSize    = 128;
+const int8_t   kNoneIndex                 = -1;
 
 /// Label for operation annotation, which captures parameters used by tools
 /// operating on a capture file.

--- a/framework/graphics/dx12_dump_resources.h
+++ b/framework/graphics/dx12_dump_resources.h
@@ -62,10 +62,8 @@ struct CopyResourceData
 
     std::vector<std::vector<uint8_t>> datas; // copy resource  drawcall
 
-    graphics::dx12::ID3D12CommandAllocatorComPtr    cmd_allocator{ nullptr };
-    graphics::dx12::ID3D12GraphicsCommandListComPtr cmd_list{ nullptr };
-    ID3D12Resource*                                 read_resource{ nullptr };
-    bool                                            read_resource_is_staging_buffer{ false };
+    ID3D12Resource* read_resource{ nullptr };
+    bool            read_resource_is_staging_buffer{ false };
 
     void Clear()
     {
@@ -80,8 +78,6 @@ struct CopyResourceData
         total_size        = 0;
         is_cpu_accessible = false;
         datas.clear();
-        cmd_allocator                   = nullptr;
-        cmd_list                        = nullptr;
         read_resource                   = nullptr;
         read_resource_is_staging_buffer = false;
     }
@@ -103,6 +99,11 @@ struct TrackDumpResources
     format::HandleId                         depth_stencil_heap_id{ format::kNullHandleId };
     D3D12_CPU_DESCRIPTOR_HANDLE              replay_depth_stencil_handle{ decode::kNullCpuAddress };
 
+    graphics::dx12::ID3D12CommandAllocatorComPtr    copy_cmd_allocator{ nullptr };
+    graphics::dx12::ID3D12GraphicsCommandListComPtr copy_cmd_list{ nullptr };
+    graphics::dx12::ID3D12ResourceComPtr            copy_staging_buffer{ nullptr };
+    uint64_t                                        copy_staging_buffer_size{ 0 };
+
     enum SplitCommandType
     {
         kBeforeDrawCall,
@@ -120,6 +121,9 @@ struct TrackDumpResources
         target.Clear();
         render_target_heap_ids.clear();
         replay_render_target_handles.clear();
+        copy_cmd_allocator  = nullptr;
+        copy_cmd_list       = nullptr;
+        copy_staging_buffer = nullptr;
     }
 };
 

--- a/framework/graphics/dx12_dump_resources.h
+++ b/framework/graphics/dx12_dump_resources.h
@@ -60,8 +60,7 @@ struct CopyResourceData
     uint64_t                                        total_size{ 0 };
     bool                                            is_cpu_accessible{ false };
 
-    std::vector<std::vector<uint8_t>> before_datas; // copy resource before drawcall
-    std::vector<std::vector<uint8_t>> after_datas;  // copy resource after drawcall
+    std::vector<std::vector<uint8_t>> datas; // copy resource  drawcall
 
     graphics::dx12::ID3D12CommandAllocatorComPtr    cmd_allocator{ nullptr };
     graphics::dx12::ID3D12GraphicsCommandListComPtr cmd_list{ nullptr };
@@ -78,28 +77,14 @@ struct CopyResourceData
         subresource_footprint_sizes.clear();
         subresource_indices.clear();
         footprints.clear();
-        before_datas.clear();
-        after_datas.clear();
-        total_size                      = 0;
-        is_cpu_accessible               = false;
+        total_size        = 0;
+        is_cpu_accessible = false;
+        datas.clear();
         cmd_allocator                   = nullptr;
         cmd_list                        = nullptr;
         read_resource                   = nullptr;
         read_resource_is_staging_buffer = false;
     }
-};
-
-struct UnorderedAccess
-{
-    CopyResourceData resource;
-    CopyResourceData counter_resource;
-};
-
-struct DescriptorHeapData
-{
-    std::vector<CopyResourceData> copy_constant_buffer_resources;
-    std::vector<CopyResourceData> copy_shader_resources;
-    std::vector<UnorderedAccess>  copy_unordered_accesses;
 };
 
 struct CommandSet
@@ -108,32 +93,15 @@ struct CommandSet
     dx12::ID3D12GraphicsCommandListComPtr list;
 };
 
-// TODO: The required data could be a piece of the ID3D12Resource, not the whole ID3D12Resource.
-//       we need to handle resource's views' offset, byte stride, count, ...
 struct TrackDumpResources
 {
     decode::TrackDumpDrawcall target{};
 
-    // vertex
-    std::vector<CopyResourceData> copy_vertex_resources;
-
-    // index
-    CopyResourceData copy_index_resource;
-
-    // descriptor
-    std::vector<DescriptorHeapData> descriptor_heap_datas;
-
     // render target
     std::vector<format::HandleId>            render_target_heap_ids;
     std::vector<D3D12_CPU_DESCRIPTOR_HANDLE> replay_render_target_handles;
-    std::vector<CopyResourceData>            copy_render_target_resources;
     format::HandleId                         depth_stencil_heap_id{ format::kNullHandleId };
     D3D12_CPU_DESCRIPTOR_HANDLE              replay_depth_stencil_handle{ decode::kNullCpuAddress };
-    CopyResourceData                         copy_depth_stencil_resource;
-
-    // ExecuteIndirect
-    CopyResourceData copy_exe_indirect_argument;
-    CopyResourceData copy_exe_indirect_count;
 
     enum SplitCommandType
     {
@@ -150,15 +118,8 @@ struct TrackDumpResources
     void Clear()
     {
         target.Clear();
-        copy_vertex_resources.clear();
-        copy_index_resource.Clear();
-        descriptor_heap_datas.clear();
         render_target_heap_ids.clear();
         replay_render_target_handles.clear();
-        copy_render_target_resources.clear();
-        copy_depth_stencil_resource.Clear();
-        copy_exe_indirect_argument.Clear();
-        copy_exe_indirect_count.Clear();
     }
 };
 
@@ -171,19 +132,21 @@ class Dx12DumpResources
 
     ~Dx12DumpResources();
 
-    void WriteResources(const TrackDumpResources& resources);
+    void StartDump(const TrackDumpResources& resources);
+    void WriteResource(const CopyResourceData&                             resource_data,
+                       const std::vector<std::pair<std::string, int32_t>>& json_path,
+                       const std::string&                                  file_name,
+                       const std::string&                                  type);
+    void CloseDump();
 
   private:
     Dx12DumpResources();
 
     HRESULT Init(const Dx12DumpResourcesConfig& config);
 
-    void WriteResources(nlohmann::ordered_json&              jdata,
-                        const std::string&                   prefix_file_name,
-                        const std::vector<CopyResourceData>& resource_datas);
-
     void WriteResource(nlohmann::ordered_json& jdata,
                        const std::string&      prefix_file_name,
+                       const std::string&      suffix,
                        const CopyResourceData& resource_data);
 
     void StartFile();
@@ -192,35 +155,25 @@ class Dx12DumpResources
     void WriteBlockEnd();
 
     constexpr const char* NameDrawCall() const { return "drawcall"; }
-    constexpr const char* NameName() const { return "name"; }
-    constexpr const char* NameArgs() const { return "args"; }
-
-    template <typename ToJsonFunctionType>
-    inline void WriteDrawCallCommandToFile(ToJsonFunctionType to_json_function)
-    {
-        using namespace util;
-        WriteBlockStart();
-
-        nlohmann::ordered_json& draw_call = json_data_[NameDrawCall()];
-        to_json_function(draw_call);
-
-        WriteBlockEnd();
-    }
 
     bool WriteBinaryFile(const std::string& filename, const std::vector<uint8_t>& data, uint64_t offset, uint64_t size);
 
-    void TestWriteReadableResources(const std::string&                   prefix_file_name,
-                                    const std::vector<CopyResourceData>& resource_datas);
-    void TestWriteReadableResource(const std::string& prefix_file_name, const CopyResourceData& resource_data);
-
-    void TestWriteFloatResource(const std::string& prefix_file_name, const CopyResourceData& resource_data);
-    void TestWriteImageResource(const std::string& prefix_file_name, const CopyResourceData& resource_data);
+    void TestWriteReadableResource(const std::string&      prefix_file_name,
+                                   const std::string&      suffix,
+                                   const CopyResourceData& resource_data);
+    void TestWriteFloatResource(const std::string&      prefix_file_name,
+                                const std::string&      suffix,
+                                const CopyResourceData& resource_data);
+    void TestWriteImageResource(const std::string&      prefix_file_name,
+                                const std::string&      suffix,
+                                const CopyResourceData& resource_data);
 
     util::JsonOptions      json_options_;
     std::string            json_filename_;
     FILE*                  json_file_handle_;
-    nlohmann::ordered_json header_;
     nlohmann::ordered_json json_data_;
+    nlohmann::ordered_json header_;
+    nlohmann::ordered_json drawcall_;
     uint32_t               num_objects_{ 0 };
     uint32_t               num_files_{ 0 };
 };


### PR DESCRIPTION
DUMPTODO: Write data to disk immediately, freeing up memory.
    In order to reduce memory use, it outputs a resource data when a copy is
    done, and release it, and then do another copy.
    
DUMPTODO: Use a single staging buffer, pre compute max needed size.
    Use a single CommandAllocator, CommandList, and Resource for all copy
    tasks, instead every copy task has its objects.